### PR TITLE
Support annotations files when loading boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ For each screenshot `example.png`, place a JSON file named `example.json` in the
 ]
 ```
 
+You can also reuse the output produced by a previous annotation run:
+
+```json
+{
+  "image": "example.png",
+  "annotations": [
+    {"id": 1, "bbox": [120, 45, 160, 85]},
+    {"id": 2, "bbox": [200, 45, 242, 87]}
+  ]
+}
+
 ```json
 {
   "boxes": [

--- a/src/annotate_icons.py
+++ b/src/annotate_icons.py
@@ -166,8 +166,13 @@ def load_icon_regions(bbox_path: Path, image_size: Tuple[int, int]) -> List[Icon
     with bbox_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
 
-    if isinstance(payload, dict) and "boxes" in payload:
-        raw_boxes: Sequence = payload["boxes"]
+    if isinstance(payload, dict):
+        if "annotations" in payload:
+            raw_boxes: Sequence = payload["annotations"]
+        elif "boxes" in payload:
+            raw_boxes = payload["boxes"]
+        else:
+            raise ValueError(f"Unsupported bounding box format in {bbox_path}")
     elif isinstance(payload, list):
         raw_boxes = payload
     else:


### PR DESCRIPTION
## Summary
- allow the CLI to read icon regions from annotation JSON payloads that include an `annotations` array
- document the new supported format in the README with an example reuse of prior results

## Testing
- python -m py_compile src/annotate_icons.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1c2b480c832683d4b9ccb2fecdca